### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+  - openjdk7

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Entity Tracker
+[![Build Status](https://travis-ci.org/Namek/artemis-odb-entity-tracker.svg?branch=master)](https://travis-ci.org/Namek/artemis-odb-entity-tracker)
 
 Server and Client that provides online tracking of [artemis-odb](https://github.com/junkdog/artemis-odb) World state.
 


### PR DESCRIPTION
This pull request adds configuration for Travis CI with JDK 7. Go to [travis-ci.org](https://travis-ci.org/) and enable it for this repository before merging; otherwise you'll have to push a dummy commit for triggering the build.
