### PR TITLE
move to artemis 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ target/
 .settings/
 .classpath
 .project
+
+# IntelliJ IDEA
+.idea/
+*.iml

--- a/artemis-entity-tracker-gui/src/main/java/net/namekdev/entity_tracker/ui/EntityTrackerMainWindow.java
+++ b/artemis-entity-tracker-gui/src/main/java/net/namekdev/entity_tracker/ui/EntityTrackerMainWindow.java
@@ -6,7 +6,6 @@ import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.util.BitSet;
 import java.util.Enumeration;
 
 import javax.swing.BoxLayout;
@@ -25,6 +24,7 @@ import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 
+import com.artemis.utils.BitVector;
 import net.namekdev.entity_tracker.connectors.WorldController;
 import net.namekdev.entity_tracker.connectors.WorldUpdateInterfaceListener;
 import net.namekdev.entity_tracker.model.ComponentTypeInfo;
@@ -184,7 +184,7 @@ public class EntityTrackerMainWindow implements WorldUpdateInterfaceListener {
 		int entityId = (int) entitiesTableModel.getValueAt(modelRow, 0);
 		int componentIndex = modelCol-1;
 
-		BitSet entityComponents = entitiesTableModel.getEntityComponents(entityId);
+		BitVector entityComponents = entitiesTableModel.getEntityComponents(entityId);
 
 		if (componentIndex >= 0 && !entityComponents.get(componentIndex)) {
 			componentIndex = -1;
@@ -204,7 +204,7 @@ public class EntityTrackerMainWindow implements WorldUpdateInterfaceListener {
 	}
 
 	@Override
-	public void addedSystem(final int index, final String name, final BitSet allTypes, final BitSet oneTypes, final BitSet notTypes) {
+	public void addedSystem(final int index, final String name, final BitVector allTypes, final BitVector oneTypes, final BitVector notTypes) {
 		final boolean hasAspect = allTypes != null || oneTypes != null || notTypes != null;
 
 		SwingUtilities.invokeLater(new Runnable() {
@@ -253,7 +253,7 @@ public class EntityTrackerMainWindow implements WorldUpdateInterfaceListener {
 	}
 
 	@Override
-	public void addedEntity(final int entityId, final BitSet components) {
+	public void addedEntity(final int entityId, final BitVector components) {
 		SwingUtilities.invokeLater(new Runnable() {
 			public void run() {
 				entitiesTableModel.addEntity(entityId, components);

--- a/artemis-entity-tracker-gui/src/main/java/net/namekdev/entity_tracker/ui/model/EntityTableModel.java
+++ b/artemis-entity-tracker-gui/src/main/java/net/namekdev/entity_tracker/ui/model/EntityTableModel.java
@@ -1,17 +1,17 @@
 package net.namekdev.entity_tracker.ui.model;
 
-import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Vector;
 
 import javax.swing.table.DefaultTableModel;
 
+import com.artemis.utils.BitVector;
 import net.namekdev.entity_tracker.model.ComponentTypeInfo;
 import net.namekdev.entity_tracker.utils.Array;
 
 public class EntityTableModel extends DefaultTableModel {
-	private Map<Integer, BitSet> _entityComponents = new HashMap<Integer, BitSet>();
+	private Map<Integer, BitVector> _entityComponents = new HashMap<>();
 	private Array<ComponentTypeInfo> _componentTypes = new Array<ComponentTypeInfo>(50);
 
 
@@ -30,13 +30,13 @@ public class EntityTableModel extends DefaultTableModel {
 		fireTableStructureChanged();
 	}
 
-	public void addEntity(int entityId, BitSet components) {
+	public void addEntity(int entityId, BitVector components) {
 		// TODO check if bitset isn't greater than before model header columns
 
 		Vector<Object> row = new Vector<Object>(components.length() + 1);
 		row.add(entityId);
 
-		for (int i = 0, n = components.size(); i < n; ++i) {
+		for (int i = 0, n = components.length(); i < n; ++i) {
 			row.add(components.get(i));
 		}
 
@@ -56,7 +56,7 @@ public class EntityTableModel extends DefaultTableModel {
 		_entityComponents.remove(entityId);
 	}
 
-	public BitSet getEntityComponents(int entityId) {
+	public BitVector getEntityComponents(int entityId) {
 		return _entityComponents.get(entityId);
 	}
 

--- a/artemis-entity-tracker-gui/src/main/java/net/namekdev/entity_tracker/ui/partials/EntityDetailsPanel.java
+++ b/artemis-entity-tracker-gui/src/main/java/net/namekdev/entity_tracker/ui/partials/EntityDetailsPanel.java
@@ -3,7 +3,6 @@ package net.namekdev.entity_tracker.ui.partials;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
-import java.util.BitSet;
 
 import javax.swing.BoxLayout;
 import javax.swing.DefaultListModel;
@@ -14,12 +13,11 @@ import javax.swing.border.BevelBorder;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.ListSelectionListener;
 
-import net.namekdev.entity_tracker.connectors.WorldController;
+import com.artemis.utils.BitVector;
 import net.namekdev.entity_tracker.model.ComponentTypeInfo;
 import net.namekdev.entity_tracker.ui.Context;
 import net.namekdev.entity_tracker.ui.model.EntityTableModel;
 import net.namekdev.entity_tracker.ui.utils.SelectionListener;
-import net.namekdev.entity_tracker.utils.Array;
 import net.namekdev.entity_tracker.utils.IndexBiMap;
 
 public class EntityDetailsPanel extends JPanel {
@@ -91,7 +89,7 @@ public class EntityDetailsPanel extends JPanel {
 		}
 
 		if (entityId != _currentEntityId) {
-			BitSet entityComponents = _entityTableModel.getEntityComponents(entityId);
+			BitVector entityComponents = _entityTableModel.getEntityComponents(entityId);
 
 			_entityTitledBorder.setTitle("Entity #" + entityId);
 

--- a/artemis-entity-tracker/pom.xml
+++ b/artemis-entity-tracker/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<artemis-odb.version>[1.0.0,2.0.0)</artemis-odb.version>
+		<artemis-odb.version>2.0.0</artemis-odb.version>
 	</properties>
 
 	<dependencies>

--- a/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/connectors/DummyWorldUpdateListener.java
+++ b/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/connectors/DummyWorldUpdateListener.java
@@ -1,7 +1,6 @@
 package net.namekdev.entity_tracker.connectors;
 
-import java.util.BitSet;
-
+import com.artemis.utils.BitVector;
 import net.namekdev.entity_tracker.model.ComponentTypeInfo;
 
 public class DummyWorldUpdateListener implements WorldUpdateListener {
@@ -15,8 +14,7 @@ public class DummyWorldUpdateListener implements WorldUpdateListener {
 	}
 
 	@Override
-	public void addedSystem(int index, String name, BitSet allTypes, BitSet oneTypes, BitSet notTypes) {
-	}
+	public void addedSystem(int index, String name, BitVector allTypes, BitVector oneTypes, BitVector notTypes) {}
 
 	@Override
 	public void addedManager(String name) {
@@ -31,8 +29,7 @@ public class DummyWorldUpdateListener implements WorldUpdateListener {
 	}
 
 	@Override
-	public void addedEntity(int entityId, BitSet components) {
-	}
+	public void addedEntity(int entityId, BitVector components) {}
 
 	@Override
 	public void deletedEntity(int entityId) {

--- a/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/connectors/WorldUpdateListener.java
+++ b/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/connectors/WorldUpdateListener.java
@@ -1,7 +1,6 @@
 package net.namekdev.entity_tracker.connectors;
 
-import java.util.BitSet;
-
+import com.artemis.utils.BitVector;
 import net.namekdev.entity_tracker.model.ComponentTypeInfo;
 
 /**
@@ -19,7 +18,7 @@ public interface WorldUpdateListener {
 
 	int getListeningBitset();
 
-	void addedSystem(int index, String name, BitSet allTypes, BitSet oneTypes, BitSet notTypes);
+	void addedSystem(int index, String name, BitVector allTypes, BitVector oneTypes, BitVector notTypes);
 
 	void addedManager(String name);
 
@@ -27,7 +26,7 @@ public interface WorldUpdateListener {
 
 	void updatedEntitySystem(int index, int entitiesCount, int maxEntitiesCount);
 
-	void addedEntity(int entityId, BitSet components);
+	void addedEntity(int entityId, BitVector components);
 
 //	void changed(Entity e);
 

--- a/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/model/AspectInfo.java
+++ b/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/model/AspectInfo.java
@@ -1,17 +1,17 @@
 package net.namekdev.entity_tracker.model;
 
-import java.util.BitSet;
+import com.artemis.utils.BitVector;
 
 public class AspectInfo {
-	public BitSet allTypes;
-	public BitSet oneTypes;
-	public BitSet exclusionTypes;
+	public BitVector allTypes;
+	public BitVector oneTypes;
+	public BitVector exclusionTypes;
 
 
 	public AspectInfo() {
 	}
 
-	public AspectInfo(BitSet allTypes, BitSet oneTypes, BitSet exclusionTypes) {
+	public AspectInfo(BitVector allTypes, BitVector oneTypes, BitVector exclusionTypes) {
 		this.allTypes = allTypes;
 		this.oneTypes = oneTypes;
 		this.exclusionTypes = exclusionTypes;

--- a/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/model/SystemInfo.java
+++ b/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/model/SystemInfo.java
@@ -1,10 +1,9 @@
 package net.namekdev.entity_tracker.model;
 
-import java.util.BitSet;
-
 import com.artemis.Aspect;
 import com.artemis.BaseSystem;
 import com.artemis.EntitySubscription;
+import com.artemis.utils.BitVector;
 
 public class SystemInfo {
 	public int systemIndex;
@@ -12,13 +11,13 @@ public class SystemInfo {
 	public BaseSystem system;
 	public Aspect aspect;
 	public AspectInfo aspectInfo;
-	public BitSet actives;
+	public BitVector actives;
 	public EntitySubscription subscription;
 	public int entitiesCount = 0;
 	public int maxEntitiesCount = 0;
 
 
-	public SystemInfo(int systemIndex, String systemName, BaseSystem system, Aspect aspect, AspectInfo aspectInfo, BitSet actives, EntitySubscription subscription) {
+	public SystemInfo(int systemIndex, String systemName, BaseSystem system, Aspect aspect, AspectInfo aspectInfo, BitVector actives, EntitySubscription subscription) {
 		this.systemIndex = systemIndex;
 		this.systemName = systemName;
 		this.system = system;

--- a/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/network/EntityTrackerServer.java
+++ b/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/network/EntityTrackerServer.java
@@ -1,11 +1,12 @@
 package net.namekdev.entity_tracker.network;
 
 import java.net.SocketAddress;
-import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.artemis.utils.Bag;
+import com.artemis.utils.BitVector;
 import net.namekdev.entity_tracker.connectors.WorldController;
 import net.namekdev.entity_tracker.connectors.WorldUpdateListener;
 import net.namekdev.entity_tracker.model.AspectInfo;
@@ -16,8 +17,6 @@ import net.namekdev.entity_tracker.network.base.RawConnectionOutputListener;
 import net.namekdev.entity_tracker.network.base.Server;
 import net.namekdev.entity_tracker.network.communicator.EntityTrackerCommunicator;
 import net.namekdev.entity_tracker.utils.tuple.Tuple3;
-
-import com.artemis.utils.Bag;
 
 /**
  * Server listening to new clients, useful to pass into Entity Tracker itself.
@@ -32,7 +31,7 @@ public class EntityTrackerServer extends Server implements WorldUpdateListener {
 	private Bag<String> _managers = new Bag<String>();
 	private Bag<Tuple3<Integer, String, AspectInfo>> _systems = new Bag<Tuple3<Integer, String, AspectInfo>>();
 	private Bag<ComponentTypeInfo> _componentTypes = new Bag<ComponentTypeInfo>();
-	private Map<Integer, BitSet> _entities = new HashMap<Integer,BitSet>();
+	private Map<Integer, BitVector> _entities = new HashMap<>();
 	private Bag<Integer> _entitySystemsEntitiesCount = new Bag<Integer>();
 	private Bag<Integer> _entitySystemsMaxEntitiesCount = new Bag<Integer>();
 
@@ -59,7 +58,7 @@ public class EntityTrackerServer extends Server implements WorldUpdateListener {
 	}
 
 	@Override
-	public void addedSystem(int index, String name, BitSet allTypes, BitSet oneTypes, BitSet notTypes) {
+	public void addedSystem(int index, String name, BitVector allTypes, BitVector oneTypes, BitVector notTypes) {
 		for (int i = 0, n = _listeners.size(); i < n; ++i) {
 			EntityTrackerCommunicator communicator = _listeners.get(i);
 			communicator.addedSystem(index, name, allTypes, oneTypes, notTypes);
@@ -96,7 +95,7 @@ public class EntityTrackerServer extends Server implements WorldUpdateListener {
 	}
 
 	@Override
-	public void addedEntity(int entityId, BitSet components) {
+	public void addedEntity(int entityId, BitVector components) {
 		for (int i = 0, n = _listeners.size(); i < n; ++i) {
 			EntityTrackerCommunicator communicator = _listeners.get(i);
 			communicator.addedEntity(entityId, components);
@@ -155,7 +154,7 @@ public class EntityTrackerServer extends Server implements WorldUpdateListener {
 						}
 					}
 
-					for (Entry<Integer, BitSet> entity : _entities.entrySet()) {
+					for (Entry<Integer, BitVector> entity : _entities.entrySet()) {
 						addedEntity(entity.getKey(), entity.getValue());
 					}
 				}

--- a/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/network/base/Server.java
+++ b/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/network/base/Server.java
@@ -21,7 +21,6 @@ public class Server implements Runnable {
 	protected final Bag<Client> clients = new Bag<Client>();
 
 	protected RawConnectionCommunicatorProvider clientListenerProvider;
-	protected int listeningBitset;
 
 
 	public Server(RawConnectionCommunicatorProvider clientListenerProvider) {

--- a/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/network/communicator/EntityTrackerCommunicator.java
+++ b/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/network/communicator/EntityTrackerCommunicator.java
@@ -1,7 +1,6 @@
 package net.namekdev.entity_tracker.network.communicator;
 
-import java.util.BitSet;
-
+import com.artemis.utils.BitVector;
 import net.namekdev.entity_tracker.connectors.WorldController;
 import net.namekdev.entity_tracker.connectors.WorldUpdateListener;
 import net.namekdev.entity_tracker.model.ComponentTypeInfo;
@@ -64,14 +63,14 @@ public class EntityTrackerCommunicator extends Communicator implements WorldUpda
 	}
 
 	@Override
-	public void addedSystem(int index, String name, BitSet allTypes, BitSet oneTypes, BitSet notTypes) {
+	public void addedSystem(int index, String name, BitVector allTypes, BitVector oneTypes, BitVector notTypes) {
 		send(
 			beginPacket(TYPE_ADDED_ENTITY_SYSTEM)
 			.addInt(index)
 			.addString(name)
-			.addBitSet(allTypes)
-			.addBitSet(oneTypes)
-			.addBitSet(notTypes)
+			.addBitVector(allTypes)
+			.addBitVector(oneTypes)
+			.addBitVector(notTypes)
 		);
 	}
 
@@ -115,11 +114,11 @@ public class EntityTrackerCommunicator extends Communicator implements WorldUpda
 	}
 
 	@Override
-	public void addedEntity(int entityId, BitSet components) {
+	public void addedEntity(int entityId, BitVector components) {
 		send(
 			beginPacket(TYPE_ADDED_ENTITY)
 			.addInt(entityId)
-			.addBitSet(components)
+			.addBitVector(components)
 		);
 	}
 

--- a/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/network/communicator/ExternalInterfaceCommunicator.java
+++ b/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/network/communicator/ExternalInterfaceCommunicator.java
@@ -1,8 +1,8 @@
 package net.namekdev.entity_tracker.network.communicator;
 
 import java.net.SocketAddress;
-import java.util.BitSet;
 
+import com.artemis.utils.BitVector;
 import net.namekdev.entity_tracker.connectors.WorldController;
 import net.namekdev.entity_tracker.connectors.WorldUpdateInterfaceListener;
 import net.namekdev.entity_tracker.model.ComponentTypeInfo;
@@ -45,9 +45,9 @@ public class ExternalInterfaceCommunicator extends Communicator implements World
 			case TYPE_ADDED_ENTITY_SYSTEM: {
 				int index = _deserializer.readInt();
 				String name = _deserializer.readString();
-				BitSet allTypes = _deserializer.readBitSet();
-				BitSet oneTypes = _deserializer.readBitSet();
-				BitSet notTypes = _deserializer.readBitSet();
+				BitVector allTypes = _deserializer.readBitVector();
+				BitVector oneTypes = _deserializer.readBitVector();
+				BitVector notTypes = _deserializer.readBitVector();
 				_listener.addedSystem(index, name, allTypes, oneTypes, notTypes);
 				break;
 			}
@@ -88,7 +88,7 @@ public class ExternalInterfaceCommunicator extends Communicator implements World
 			}
 			case TYPE_ADDED_ENTITY: {
 				int entityId = _deserializer.readInt();
-				BitSet components = _deserializer.readBitSet();
+				BitVector components = _deserializer.readBitVector();
 				_listener.addedEntity(entityId, components);
 				break;
 			}

--- a/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/utils/serialization/NetworkDeserializer.java
+++ b/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/utils/serialization/NetworkDeserializer.java
@@ -1,6 +1,6 @@
 package net.namekdev.entity_tracker.utils.serialization;
 
-import java.util.BitSet;
+import com.artemis.utils.BitVector;
 
 public class NetworkDeserializer extends NetworkSerialization {
 	private byte[] _source;
@@ -99,15 +99,15 @@ public class NetworkDeserializer extends NetworkSerialization {
 		return Double.longBitsToDouble(readRawLong());
 	}
 
-	public BitSet readBitSet() {
+	public BitVector readBitVector() {
 		if (checkNull()) {
 			return null;
 		}
 
-		checkType(TYPE_BITSET);
+		checkType(Type_BITVECTOR);
 
 		final short allBitsCount = readRawShort();
-		final BitSet bitset = new BitSet(allBitsCount);
+		final BitVector bitVector = new BitVector(allBitsCount);
 
 		int i = 0;
 		while (i < allBitsCount) {
@@ -118,13 +118,13 @@ public class NetworkDeserializer extends NetworkSerialization {
 
 			for (int j = 0; j < nBits; ++j, ++i) {
 				if ((value & 1) == 1) {
-					bitset.set(i);
+					bitVector.set(i);
 				}
 				value >>= 1;
 			}
 		}
 
-		return bitset;
+		return bitVector;
 	}
 
 	public byte readRawByte() {
@@ -174,8 +174,8 @@ public class NetworkDeserializer extends NetworkSerialization {
 		else if (type == TYPE_DOUBLE) {
 			return readDouble();
 		}
-		else if (type == TYPE_BITSET) {
-			return readBitSet();
+		else if (type == Type_BITVECTOR) {
+			return readBitVector();
 		}
 		else if (allowUnknown) {
 			_sourcePos++;

--- a/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/utils/serialization/NetworkSerialization.java
+++ b/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/utils/serialization/NetworkSerialization.java
@@ -1,6 +1,6 @@
 package net.namekdev.entity_tracker.utils.serialization;
 
-import java.util.BitSet;
+import com.artemis.utils.BitVector;
 
 public abstract class NetworkSerialization {
 	public final static byte TYPE_UNKNOWN = 1;
@@ -15,7 +15,7 @@ public abstract class NetworkSerialization {
 	public final static byte TYPE_BOOLEAN = 15;//takes 1 byte
 	public final static byte TYPE_FLOAT = 16;
 	public final static byte TYPE_DOUBLE = 17;
-	public final static byte TYPE_BITSET = 20;//takes minimum 4 bytes
+	public final static byte Type_BITVECTOR = 20;//takes minimum 4 bytes
 
 
 	public static NetworkSerializer createSerializer() {
@@ -57,8 +57,8 @@ public abstract class NetworkSerialization {
 		else if (type.equals(float.class)) {
 			netType = TYPE_DOUBLE;
 		}
-		else if (type.equals(BitSet.class)) {
-			netType = TYPE_BITSET;
+		else if (type.equals(BitVector.class)) {
+			netType = Type_BITVECTOR;
 		}
 
 		return netType;
@@ -74,7 +74,7 @@ public abstract class NetworkSerialization {
 			case TYPE_BOOLEAN: return Boolean.valueOf(value);
 			case TYPE_FLOAT: return Float.valueOf(value);
 			case TYPE_DOUBLE: return Double.valueOf(value);
-			case TYPE_BITSET: return new BitSet(Integer.valueOf(value));
+			case Type_BITVECTOR: return new BitVector(Integer.valueOf(value));
 			case TYPE_ARRAY: throw new UnsupportedOperationException("arrays are not supported (yet?)");
 			default: return null;
 		}

--- a/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/utils/serialization/NetworkSerializer.java
+++ b/artemis-entity-tracker/src/main/java/net/namekdev/entity_tracker/utils/serialization/NetworkSerializer.java
@@ -1,6 +1,6 @@
 package net.namekdev.entity_tracker.utils.serialization;
 
-import java.util.BitSet;
+import com.artemis.utils.BitVector;
 
 public class NetworkSerializer extends NetworkSerialization {
 	private byte[] _ourBuffer;
@@ -135,21 +135,21 @@ public class NetworkSerializer extends NetworkSerialization {
 		return this;
 	}
 
-	public NetworkSerializer addBitSet(BitSet bitset) {
-		if (tryAddNullable(bitset)) {
+	public NetworkSerializer addBitVector(BitVector bitVector) {
+		if (tryAddNullable(bitVector)) {
 			return this;
 		}
 
-		_buffer[_pos++] = TYPE_BITSET;
+		_buffer[_pos++] = Type_BITVECTOR;
 
-		int bitsCount = bitset.length();
+		int bitsCount = bitVector.length();
 		addRawShort((short) bitsCount);
 
 		int i = 0, value;
 		while (i < bitsCount) {
 			value = 0;
 			for (int j = 0; j < Integer.SIZE && j < bitsCount; ++j, ++i) {
-				boolean bit = bitset.get(i);
+				boolean bit = bitVector.get(i);
 
 				if (bit) {
 					value |= 1 << j;
@@ -203,8 +203,8 @@ public class NetworkSerializer extends NetworkSerialization {
 		else if (object instanceof Double) {
 			addDouble(((Double) object).doubleValue());
 		}
-		else if (object instanceof BitSet) {
-			addBitSet(((BitSet) object));
+		else if (object instanceof BitVector) {
+			addBitVector((BitVector) object);
 		}
 		else if (allowUnknown) {
 			_buffer[_pos++] = TYPE_UNKNOWN;

--- a/artemis-entity-tracker/src/test/java/net/namekdev/entity_tracker/utils/serialization/NetworkSerializationTest.java
+++ b/artemis-entity-tracker/src/test/java/net/namekdev/entity_tracker/utils/serialization/NetworkSerializationTest.java
@@ -1,13 +1,11 @@
 package net.namekdev.entity_tracker.utils.serialization;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.BitSet;
-
+import com.artemis.utils.BitVector;
 import net.namekdev.entity_tracker.utils.serialization.NetworkSerializer.SerializeResult;
-
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class NetworkSerializationTest {
 	NetworkSerializer serializer;
@@ -49,47 +47,48 @@ public class NetworkSerializationTest {
 	}
 
 	@Test
-	public void testBitsets() {
-		BitSet bitset1 = new BitSet();
-		bitset1.set(0);
-		bitset1.set(2);
-		bitset1.set(5);
-		bitset1.set(31);
-		bitset1.set(32);
-		bitset1.set(63);
-		bitset1.set(64);
-		bitset1.set(80);
+	public void testBitVector() {
+		BitVector bitVector1 = new BitVector();
+		bitVector1.set(0);
+		bitVector1.set(2);
+		bitVector1.set(5);
+		bitVector1.set(31);
+		bitVector1.set(32);
+		bitVector1.set(63);
+		bitVector1.set(64);
+		bitVector1.set(80);
 
-		BitSet bitset2 = new BitSet();
-		bitset2.set(1);
-		bitset2.set(4);
-		bitset2.set(74);
+		BitVector bitVector2 = new BitVector();
+		bitVector2.set(1);
+		bitVector2.set(4);
+		bitVector2.set(74);
 
-		BitSet bitset3 = new BitSet(20);
+		BitVector bitVector3 = new BitVector(20);
 		for (int index : new int[] { 2, 3, 4, 5, 6, 7, 10, 11, 14, 15, 16, 18, 19 }) {
-			bitset3.set(index);
+			bitVector3.set(index);
 		}
 
-		BitSet bitset4 = new BitSet();
-		bitset4.set(0);
-		bitset4.set(7);
-		bitset4.set(10);
+		BitVector bitVector4 = new BitVector();
+		bitVector4.set(0);
+		bitVector4.set(7);
+		bitVector4.set(10);
 
 		serializer.reset();
-		serializer.addBitSet(bitset1);
-		serializer.addBitSet(bitset2);
-		serializer.addBitSet(bitset1);
-		serializer.addBitSet(bitset3);
-		serializer.addBitSet(bitset4);
+		serializer.addBitVector(bitVector1);
+		serializer.addBitVector(bitVector2);
+		serializer.addBitVector(bitVector1);
+		serializer.addBitVector(bitVector3);
+		serializer.addBitVector(bitVector4);
 		SerializeResult result = serializer.getResult();
 
 		deserializer.setSource(result.buffer, 0, result.size);
-		assertEquals(bitset1, deserializer.readBitSet());
-		assertEquals(bitset2, deserializer.readBitSet());
-		assertEquals(bitset1, deserializer.readBitSet());
-		assertEquals(bitset3, deserializer.readBitSet());
-		assertEquals(bitset4, deserializer.readBitSet());
+		assertEquals(bitVector1, deserializer.readBitVector());
+		assertEquals(bitVector2, deserializer.readBitVector());
+		assertEquals(bitVector1, deserializer.readBitVector());
+		assertEquals(bitVector3, deserializer.readBitVector());
+		assertEquals(bitVector4, deserializer.readBitVector());
 
 		assertEquals(result.size, deserializer.getConsumedBytesCount());
 	}
+
 }


### PR DESCRIPTION
Ref: https://github.com/Namek/artemis-odb-entity-tracker/issues/7 (it won't be compatible to 1.4.0 but to 2.0.0, the newest version of artemis-odb)

Mostly I replaced `BitSet` with `BitVector` which makes it compatible to artemis-odb:2.0.0.
