### PR TITLE
Update readme to reference latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Entity Tracker
+
 [![Build Status](https://travis-ci.org/Namek/artemis-odb-entity-tracker.svg?branch=master)](https://travis-ci.org/Namek/artemis-odb-entity-tracker)
 
 Server and Client that provides online tracking of [artemis-odb](https://github.com/junkdog/artemis-odb) World state.
@@ -15,14 +16,14 @@ Server and Client that provides online tracking of [artemis-odb](https://github.
 <dependency>
 	<groupId>net.namekdev.entity_tracker</groupId>
 	<artifactId>artemis-entity-tracker</artifactId>
-	<version>0.3.0</version>
+	<version>0.4.0-SNAPSHOT</version>
 </dependency>
 
 <!-- uncomment in case you need GUI inside your game -->
 <!--dependency>
 	<groupId>net.namekdev.entity_tracker</groupId>
 	<artifactId>artemis-entity-tracker-gui</artifactId>
-	<version>0.3.0</version>
+	<version>0.4.0-SNAPSHOT</version>
 </dependency-->
 ```
 
@@ -30,10 +31,10 @@ Server and Client that provides online tracking of [artemis-odb](https://github.
 
 ```groovy
 dependencies {
-	compile "net.namekdev.entity_tracker:artemis-entity-tracker:0.3.0"
-	
+	compile "net.namekdev.entity_tracker:artemis-entity-tracker:0.4.0-SNAPSHOT"
+
 	// uncomment in case you need GUI instantiated directly from your game
-	// compile "net.namekdev.entity_tracker:artemis-entity-tracker-gui:0.3.0"
+	// compile "net.namekdev.entity_tracker:artemis-entity-tracker-gui:0.4.0-SNAPSHOT"
 }
 ```
 
@@ -43,7 +44,6 @@ dependencies {
 
 Import both `Entity Tracker` and `Entity Tracker GUI` libraries into your project.
 
-
 ```java
 artemisWorld.setManager(new EntityTracker(new EntityTrackerMainWindow()));
 ```
@@ -51,6 +51,7 @@ artemisWorld.setManager(new EntityTracker(new EntityTrackerMainWindow()));
 ## Option 2. Network Connection
 
 Host `Entity Tracker Server` inside your game:
+
 ```java
 EntityTrackerServer entityTrackerServer = new EntityTrackerServer();
 entityTrackerServer.start();
@@ -61,6 +62,7 @@ There are 2 options to run `Entity Tracker GUI` that connects with `EntityTracke
 
 1. run external app (you can download `*-app` from [releases](https://github.com/Namek/artemis-odb-entity-tracker/releases)) or build it yourself (see `Build` section below)
 2. run [StandaloneMain.java](artemis-entity-tracker-gui/src/main/java/net/namekdev/entity_tracker/StandaloneMain.java) file or setup GUI manually:
+
 ```java
 final EntityTrackerMainWindow window = new EntityTrackerMainWindow();
 final Client client = new PersistentClient(new ExternalInterfaceCommunicator(window));
@@ -73,7 +75,6 @@ client.connect(serverName, serverPort);
 Generally speaking, `EntityTracker` expects `WorldUpdateListener` interface implementation, e.g. it may be some window listener.
 
 To achieve network version one can just mimic implementation of `ExternalInterfaceCommunicator` by implementing `Communicator` interface and passing it to `Client`.
-
 
 ## Build
 


### PR DESCRIPTION
I was getting BitSet vs BitVector runtime errors and was going to fork and update this myself when I noticed version 0.3.0 from following the readme is old and the problem has already been addressed.

Having readme on latest version will likely help people new to this like me.